### PR TITLE
Lab8, Ignore Lost+Found of PVC with ext4

### DIFF
--- a/content/en/docs/08.0/_index.en.md
+++ b/content/en/docs/08.0/_index.en.md
@@ -98,6 +98,8 @@ spec:
       containers:
       - image: mysql:5.7
         name: mysql
+        args:
+        - "--ignore-db-dir=lost+found"
         env:
         - name: MYSQL_ROOT_PASSWORD
           valueFrom:


### PR DESCRIPTION
As a PVC with an ext4 FS has the "Lost+Found" directory, we have to ignore this. Otherwise the mysql pod does not start