### PR TITLE
Extend security labs

### DIFF
--- a/content/en/docs/security/_index.md
+++ b/content/en/docs/security/_index.md
@@ -4,3 +4,4 @@ weight: 10
 onlyWhenNot: nosecurity
 ---
 
+The following exercises will demonstrate various security-related aspects of Kubernetes clusters in multi-user and multi-tenant setups.

--- a/content/en/docs/security/admission-control/_index.md
+++ b/content/en/docs/security/admission-control/_index.md
@@ -1,0 +1,62 @@
+---
+title: "Admission Control"
+weight: 104
+onlyWhen: openshift
+---
+
+## Admission Control
+
+Not every restriction you wish to impose on cluster usage can be expressed as an
+RBAC rule. Frequently, organisations want to enable users to perform certain tasks
+while limiting their options to a subset of what the platform itself allows. For
+example, users should be able to create `Service` resources, but `Services` of
+`type: LoadBalancer` (which the cloud provider charges extra for) should be
+restricted to specific privileged namespaces. Or a multi-tenant cluster might
+enforce `imagePullPolicy: Always` in user namespaces to ensure pull credential
+verification with private images (at least until a [better
+solution](https://kubernetes.io/docs/concepts/containers/images/#ensureimagepullcredentialverification)
+becomes generally available).
+
+There is a wide range of these typically site-specific _policy decisions_, that
+require additional capabilities to validate or even modify API requests beyond
+the base capabilities of the Kubernetes control plane. To address these needs,
+the API server offers a flexible subsystem for _admission control_. It
+ships with numerous pre-defined admission controllers (such as `PodSecurity` or
+`ResourceQuota`) that can be enabled or disabled according to individual needs.
+In OpenShift, this list is managed by the platform and cannot be manually reconfigured.
+However, admission control can still be extended effectively because the
+default controllers include a generic, webhook-based interface where additional
+plugins can be injected.
+
+Traditionally, dedicated policy engines such as [Open Policy
+Agent/Gatekeeper](https://kubernetes.io/blog/2019/08/06/opa-gatekeeper-policy-and-governance-for-kubernetes/)
+or [Kyverno](https://kyverno.io/) have utilised this mechanism to provide a
+flexible option for admins to configure and enforce site-specific regulations.
+In recent versions of Kubernetes, this process has become even more straightforward.
+Starting with version 1.30 (or OpenShift 4.17),
+[`ValidatingAdmissionPolicy`](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/)
+was added to the stable set of native Kubernetes resources. It allows
+incoming requests to be checked against a list of rules in Common Expression Language
+(CEL) format, allowing or denying the request based on the outcome.
+
+Its companion,
+[`MutatingAdmissionPolicy`](https://kubernetes.io/docs/reference/access-authn-authz/mutating-admission-policy/)
+remains in beta as of Kubernetes 1.34, and is therefore not yet available in OpenShift
+by default. Unlike its validating counterpart, it can modify parts of a
+request on the fly. Until this feature graduates to `stable`, administrators
+must resort to external policy engines if they wish to adjust
+incoming manifests to comply with site restrictions, rather than simply rejecting
+them.
+
+### {{% task %}} Explore Admission Control
+
+The lab environment already includes a few sample policies that you can explore
+to familiarise yourself with [CEL](https://cel.dev/),
+[`ValidatingAdmissionPolicy`
+objects](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/)
+and their related `ValidatingAdmissionPolicyBindings`. You will not have
+privileges required to add or modify these resources, but you can ask your
+tutors to check and apply them for you -- once they are confident it will not
+impair cluster operations... You may also wish to take a look at the
+[Kubescape](https://kubescape.io/) project, which provides a curated list of
+policy examples.

--- a/content/en/docs/security/openshift-security-contexts/_index.md
+++ b/content/en/docs/security/openshift-security-contexts/_index.md
@@ -1,0 +1,163 @@
+---
+title: "Security contexts constraints"
+weight: 102
+onlyWhen: openshift
+---
+
+## Security Context and Context Constraints
+
+The [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+of a `Pod` or container informs the container runtime about the
+privileges, capabilities, and desired level of isolation for a
+containerised workload:
+
+* Access control
+* Running privileged or unprivileged workloads
+* Linux capabilities
+* Seccomp
+* SELinux
+
+OpenShift offers a custom resource, the
+[SecurityContextConstraint](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/authentication_and_authorization/managing-pod-security-policies)
+(SCC), to manage sensible defaults and control what users are allowed to configure.
+In this lab, you will learn some simple but common use cases for adjusting
+the security context and how to make use of SCCs.
+
+### {{% task %}} Container UID and GIDs
+
+Provision a new project and add a workload from one of the OpenShift-provided
+samples. You can use the Quick Create button (the plus sign) in the upper right
+corner, select 'Container images', and create a `Deployment` from an 'Image
+stream tag from internal registry'. One of the Apache webservers located in the
+'openshift' project, Image Stream 'httpd' is a good choice. Any tag will do.
+Provide an arbitrary name and leave the remaining settings at their defaults.
+Creating a route is not necessary. The deployment will spawn a single httpd `Pod`.
+
+Open a terminal in this `Pod` and run the 'id' command to investigate the numeric
+User ID (UID) and Group IDs (GIDs) assigned to the container. Note that a seemingly
+random UID from a high range was chosen. This is one of the idiosyncrasies of OpenShift
+compared to other Kubernetes platforms, and a common source of problems for
+certain workloads that expect to run with a well-known UID, such as '1000'.
+
+Switch to the YAML view for the `Deployment` (or use 'oc edit'), and attempt to
+run the httpd container with UID 1000, and GIDs 1000, 2000, and 3000. This is
+achieved by modifying the `Pod`'s security context:
+
+{{% alert title="Note" color="primary" %}}
+There are `securityContext` parameters at both the `Pod` and the container level.
+Some options may be set in either of thoses
+contexts, while others are specific to one, or the other.
+{{% /alert %}}
+
+```yaml
+spec:
+  template:
+    spec:
+      # (...)
+      # Pod-level security context!
+      # runAs* can also be set at container level
+      # supplementalGroups is only valid at Pod level
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        supplementalGroups: [2000, 3000]
+```
+
+While the deployment accepts the modification, it will fail to roll out an updated `Pod`
+with the new settings. Its status will show a long list of 'Forbidden' error messages
+similar to the following:
+
+```
+pods "httpd-6d788c7686-" is forbidden: unable to validate against any security context constraint: [provider "anyuid": Forbidden: not usable by user or serviceaccount, provider restricted-v2: .containers[0].runAsUser: Invalid value: 1000: must be in the ranges: [1000940000, 1000949999], provider "restricted-v3": Forbidden: not usable by user or serviceaccount, provider "restricted": Forbidden: not usable by user or serviceaccount, provider "nonroot-v2": Forbidden: not usable by user or serviceaccount,(...)
+```
+
+Note the section `Invalid value: 1000: must be in the ranges: [1000940000,
+1000949999]` (the specific range you see will be different). Inspect the annotations on
+your 'Project' for this lab task, where you will find two keys:
+`openshift.io/sa.scc.uid-range`, and `openshift.io/sa.scc.supplemental-groups`.
+These values were auto-generated when the project was
+created and contain an assigned range for User and Group IDs that does not
+overlap with other projects in the same cluster.
+They can only be changed with elevated privileges beyond those of a regular project admin.
+
+Back in the YAML view for the `Deployment`, change the UID in the `runAsUser`
+parameter from 1000 to the last uid from the assigned range (here: 1000949999),
+but leave the `runAsGroup` and `supplementalGroups` parameters at their current
+values. The deployment should now be able to spawn a new `Pod` with the updated
+configuration. Switch to the terminal view for the `Pod`, and run 'id' to verify
+the assignments.
+
+Finally, add the `fsGroup` parameter to the pod's (not the container's!) security context.
+Try to set different, arbitrary IDs. There is only one specific value that is accepted during
+pod re-creation, and that is the GID that would also be assigned by default
+(here: 1000940000). The `fsGroup` parameter is used to change ownership when
+attaching volumes to a `Pod`, and its (default or explicit) value is always added
+as a supplemental GID.
+
+These are just some of the most basic settings controlled by a security context.
+Check the documentation at kubernetes.io to view all the examples for
+[Security Contexts](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
+
+### {{% task %}} Security Context Constraints
+
+Having explored what security contexts can do, you will now investigate
+how OpenShift controls them. Run the following command to determine your
+privileges regarding the OpenShift-specific 'SecurityContextConstraint' resource:
+
+```bash
+oc auth can-i --list | grep securitycontextconstraints.security.openshift.io
+securitycontextconstraints.security.openshift.io                              []                                          [restricted-v2]                                                    [use]
+```
+
+The output shows that you are permitted to 'use' exactly one SCC called
+'restricted-v2', but you are not permitted to view its content ('get').
+To proceed, ask your tutors to assign additional privileges to your user, or
+follow along as they demonstrate the next sections.
+
+By default, OpenShift clusters ship with a ClusterRole for 'use'
+privileges on the 'restricted-v2' SCC. This is typically assigned 
+to the 'system:authenticated' group (that is all users and
+service accounts with a valid login session). However, there are several other
+SCCs available in the clusters, three of which are most commonly encountered in
+user projects:
+
+```bash
+oc get scc restricted-v2,restricted-v3,nonroot-v2 -o wide
+NAME            PRIV    CAPS                   SELINUX     RUNASUSER          FSGROUP     SUPGROUP    PRIORITY     READONLYROOTFS   VOLUMES
+restricted-v2   false   ["NET_BIND_SERVICE"]   MustRunAs   MustRunAsRange     MustRunAs   RunAsAny    <no value>   false            ["configMap","csi","downwardAPI","emptyDir","ephemeral","persistentVolumeClaim","projected","secret"]
+restricted-v3   false   ["NET_BIND_SERVICE"]   MustRunAs   MustRunAsRange     MustRunAs   MustRunAs   <no value>   false            ["configMap","csi","downwardAPI","emptyDir","ephemeral","persistentVolumeClaim","projected","secret"]
+nonroot-v2      false   ["NET_BIND_SERVICE"]   MustRunAs   MustRunAsNonRoot   RunAsAny    RunAsAny    <no value>   false            ["configMap","csi","downwardAPI","emptyDir","ephemeral","persistentVolumeClaim","projected","secret"]
+```
+
+Note how 'restricted-v2' restricts the user to the UID range configured in the project
+annotation (`MustRunAsRange`), and the fsGroup to the project's default value
+(`MustRunAs`). Crucially, it imposes no limits on supplemental groups (`RunAsAny`), even
+if a range is configured in the project's annotation. This explains why
+only the `runAsUser` modifications were blocked in your earlier tests, while
+groups could be set to arbitrary values (including GID 0!).
+
+In contrast, the more recent 'restricted-v3' SCC honours the project annotation
+to enforce limits on the allowed GID range. It also includes security enhancements
+not visible in the brief `-o wide` overview, and is not yet assigned to any subjects
+by default.
+
+The 'nonroot-v2' SCC is a common choice when workloads cannot be easily
+adjusted to accommodate OpenShift's randomly assigned UIDs. It is similar to
+'restricted-v2', but allows 'runAsUser' to be configured to any arbitrary value
+except for UID 0. Unless already done, ask your tutors to assign this privilege
+to your user. (The privilege is needed by a service account in the end, but you
+can only grant privileges that you hold.) Next, to replicate a realistic production
+setup, follow these steps:
+
+1. Create a new service account in your project.
+2. Update your `httpd` `Deployment` to use this 'serviceAccountName'.
+3. Assign 'use' privileges for the 'nonroot-v2' SCC to this service account.
+   You can reference the default 'system:openshift:scc:nonroot-v2' ClusterRole.
+4. Re-run the previous tests and verify that the `Pods` can now start with arbitrary
+   non-root UIDs.
+
+{{% alert title="Warning" color="warning" %}}
+Do not confuse 'nonroot-v2' with the 'anyuid' SCC. The latter permits UID 0, which
+poses a significant security risk and should be avoided whenever possible.
+{{% /alert %}}
+

--- a/content/en/docs/security/user-management/_index.md
+++ b/content/en/docs/security/user-management/_index.md
@@ -1,0 +1,150 @@
+---
+title: "User and Identity Management"
+weight: 103
+onlyWhen: openshift
+---
+
+## User and Identity Management
+
+So far, you have interacted with the OpenShift cluster using your own account,
+leveraging privileges assigned to your user's groups.  This
+likely felt natural, as it is exactly what one would expect from any multi-user
+system. It may, therefore, come as a surprise that Kubernetes does not actually
+include any native user management capabilities. Yet, running `oc whoami` clearly
+indicates that the system identifies you as a user. How do we reconcile these
+two facts?
+
+Your tutors will now assign additional privileges to your account to enable
+you to inspect the `User`, `Group`, and `Identity` resources. Take a
+look at the YAML representation of one of these, specifically the
+`apiVersion` field: you will notice they are OpenShift-specific extensions.
+Other Kubernetes distributions may ship their own abstractions for user management,
+or might not include any at all.
+
+In OpenShift, user management revolves around the configuration of its
+built-in OAuth service. Your new privileges allow you to examine
+its primary configuration in the `OAuth` custom resource called `cluster`. This
+resource defines how the cluster integrates with one or more identity providers,
+commonly using protocols such as OpenID Connect or LDAP, or even simple
+implementations based on a plain 'htpasswd' file.
+
+These identity providers determine how users _authenticate_ to the system.
+Upon the first login, an account from one of these providers is reflected by
+an `Identity` custom resource. Each `Identity` then maps onto a `User` resource
+based on a strategy defined in the `OAuth` configuration. For example, an
+`Identity` can correspond to exactly one `User` ('claim it'). If a
+person is permitted to log in via multiple identity providers, `Oauth can
+be configured to map multiple `Identities` to the same `User`.
+
+When Kubernetes needs to _authorise_ a request, it does not refer to the
+`Identity`, but to the `User` (or a `Group`, which is a collection of
+`Users`). Recall the `subjects` parameter in a `RoleBinding` or
+`ClusterRoleBinding`: it allows you to specify users, groups, or `ServiceAccounts`.
+Remarkably, only the `ServiceAccount` is a first-class citizen
+in native Kubernetes that is always reflected as an API resource, whereas the other
+two lack a standardised internal representation across the wider Kubernetes ecosystem.
+
+If native Kubernetes has no notion of users as API objects, and relies on
+distribution-specific add-ons, then how does the system function before they are
+even installed? In the next lab, you will create users that aren't there.
+
+### {{% task %}} Creating a Stealth Account
+
+Kubernetes may be agnostic to user management, but it still maintains a notion
+of users (and groups). Its most native method for identifying users leverages
+X.509 certificates. Once a suitable certificate is signed by a cluster's
+trusted Certificate Authority (CA), users can authenticate with it when
+communicating with the API server. There is no user database or external management
+involved: The Common Name attribute (CN) in the certificate's subject DN is
+interpreted as the user name, and any Organization (O) attribute indicates group
+membership. This scheme is simple and incurs very little overhead, but it comes at
+a price. Once a certificate is signed, Kubernetes does not offer a native way to
+track or revoke it (ie. you cannot easily see a list of which users are 'out there').
+If a compromise is suspected, the only practical way to invalidate a certificate is
+to rotate the CA's keys, which unfortunately invalidates every other certificate
+issued by that CA as well!
+
+Let's try this in practice by creating an account with
+`cluster-reader` privileges and using certificate-based authentication. Your tutors
+have granted you the privilege to create a `CertificateSigningRequest` (CSR). This
+is a Kubernetes resource that wraps a PKCS#10 signing request with additional
+metadata. Start out by creating a new private key
+and the associated signing request:
+
+```bash
+export OCPUSER=$(oc whoami)
+
+openssl genrsa -out tls.key 2048
+# We define the CN as our username and 'O' as our groups
+openssl req -new -key tls.key -out tls.csr -subj "/CN=${OCPUSER}-reader/O=system:cluster-readers/O=stealth-group"
+
+export CSR_BASE64=$(base64 -w0 < tls.csr)
+
+cat <<EOF > "csr-$OCPUSER.yaml"
+apiVersion: certificates.k8s.io/v1
+kind: CertificateSigningRequest
+metadata:
+  name: csr-${OCPUSER}
+spec:
+  request: ${CSR_BASE64}
+  # required for user certs
+  signerName: kubernetes.io/kube-apiserver-client
+  # 30 days
+  expirationSeconds: 2592000
+  usages:
+  # required for user certs
+  - client auth
+EOF
+```
+
+Run `oc apply -f csr-$OCPUSER.yaml` to upload the request. Once a tutor has
+approved it, retrieve the signed certificate using the following command:
+
+```bash
+oc get csr csr-$OCPUSER -o go-template='{{ .status.certificate | base64decode }}' > tls.crt
+```
+
+All that remains is to build a valid kubeconfig file. You are already connected
+to the cluster and have a valid config at hand (albeit for a different account),
+that you could clone and modify. But as a useful excercise, you can run the following
+script that pieces together the necessary bits:
+
+```bash
+#!/bin/bash
+
+OUTFILE=user.kubeconfig
+
+# ConfigMap containing the CA bundle is injected into every namespace
+oc get configmap kube-root-ca.crt -o go-template='{{ index .data "ca.crt" }}' > ca-bundle.crt
+
+# Lazy way to retrieve the API server URL from the current-context
+APISERVERURL=$(oc cluster-info | sed -ne 's,.*\(https://.*\),\1,p')
+
+oc config set-cluster default-cluster \
+  --server=${APISERVERURL} \
+  --certificate-authority=ca-bundle.crt \
+  --embed-certs=true \
+  --kubeconfig=$OUTFILE
+
+oc config set-credentials default-user \
+  --client-certificate=tls.crt \
+  --client-key=tls.key \
+  --embed-certs=true \
+  --kubeconfig=$OUTFILE
+
+oc config set-context default-context \
+  --cluster=default-cluster \
+  --user=default-user \
+  --kubeconfig=$OUTFILE
+
+oc config use-context default-context --kubeconfig=$OUTFILE
+```
+
+Now, call `oc --kubeconfig=user.kubeconfig whoami` to test the new configuration.
+Using `oc --kubeconfig=user.kubeconfig auth whoami` (note the extra `auth` keyword!),
+you can verify your assigned group memberships. Observe the total absence of any associated
+`User` or `Group` resources! Despite this, `oc --kubeconfig=user.kubeconfig auth can-i
+--list` will show that this 'stealth' account possesses extensive
+read-only privileges across the entire cluster. Use this access to further explore the
+inner workings of OpenShift!
+


### PR DESCRIPTION
Add new lab sections to the security chapter for the following topics:

- OpenShift Security Context Constraints
- User Management in Kubernetes and OpenShift
- Admission control basics